### PR TITLE
[김택향] 카카오 API 를 이용한 소셜 로그인 구현

### DIFF
--- a/mukbang/urls.py
+++ b/mukbang/urls.py
@@ -1,20 +1,6 @@
-"""mukbang URL Configuration
+from django.urls import path, include
 
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/3.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-from django.contrib import admin
-from django.urls import path
 
 urlpatterns = [
+    path('user', include('user.urls')),
 ]

--- a/user/tests.py
+++ b/user/tests.py
@@ -1,3 +1,72 @@
-from django.test import TestCase
+import json
+import requests
 
-# Create your tests here.
+from django.test import TestCase
+from django.test import Client
+from django.http import JsonResponse
+
+from unittest.mock import patch, MagicMock, Mock
+
+from .views import KakaoLoginView
+
+
+class KakaoLoginTest(TestCase):
+    def test_kakaologin_get_success(self):
+        mock_content  = {'id': '12345678', 'properties': {'nickname': 'test_nickname'}}
+
+        mock_response          = requests.Response()
+        mock_response._content = bytes(json.dumps(mock_content), 'utf-8')
+
+        with patch('requests.get', return_value=mock_response):
+            client = Client()
+            params = {'access_token': 'test_access_token'}
+            response = client.get('/user/login/kakao', data=params, content_type='application/json').json()
+
+            self.assertEqual(response.get('nickname'), 'test_nickname')
+            self.assertTrue(response.get('token'), True)
+
+    def test_kakaologin_get_fail_access_token_not_exist(self):
+        client = Client()
+        params = {'access_token': ''}
+        response = client.get('/user/login/kakao', data=params, content_type='application/json').json()
+
+        self.assertEqual(response.get('message'), 'ACCESS_TOKEN_DOES_NOT_EXIST')
+
+    def test_kakaologin_get_fail_with_error_code(self):
+        mock_content  = {'code': -401}
+
+        mock_response          = requests.Response()
+        mock_response._content = bytes(json.dumps(mock_content), 'utf-8')
+
+        with patch('requests.get', return_value=mock_response):
+            client = Client()
+            params = {'access_token': 'test_access_token'}
+            response = client.get('/user/login/kakao', data=params, content_type='application/json').json()
+
+        self.assertIn('code -401', response.get('message'))
+
+    def test_kakaologin_get_fail_with_invalid_token(self):
+        mock_content  = {'id': ''}
+
+        mock_response          = requests.Response()
+        mock_response._content = bytes(json.dumps(mock_content), 'utf-8')
+
+        with patch('requests.get', return_value=mock_response):
+            client = Client()
+            params = {'access_token': 'test_access_token'}
+            response = client.get('/user/login/kakao', data=params, content_type='application/json').json()
+
+        self.assertEqual(response.get('message'), 'INVALID_ACCESS_TOKEN')
+
+    def test_kakaologin_get_fail_with_key_error(self):
+        mock_content  = {'id': '12345678'}
+
+        mock_response          = requests.Response()
+        mock_response._content = bytes(json.dumps(mock_content), 'utf-8')
+
+        with patch('requests.get', return_value=mock_response):
+            client = Client()
+            params = {'access_token': 'test_access_token'}
+            response = client.get('/user/login/kakao', data=params, content_type='application/json').json()
+
+        self.assertEqual(response.get('message'), 'KEY_ERROR')

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import KakaoLoginView
+
+urlpatterns = [
+    path('/login/kakao', KakaoLoginView.as_view()),
+]

--- a/user/views.py
+++ b/user/views.py
@@ -1,3 +1,45 @@
-from django.shortcuts import render
+import jwt
+import requests
+import uuid
 
-# Create your views here.
+from django.shortcuts import redirect
+from django.views     import View
+from django.http      import JsonResponse
+
+from .models import User
+
+from my_settings import SECRET_KEY, HASHING_ALGORITHM, KAKAO_RESTAPI_KEY
+
+
+KAKAO_USERINFO_REQUEST_URL = 'https://kapi.kakao.com/v2/user/me'
+
+
+class KakaoLoginView(View):
+    def get(self, request):
+        try:
+            access_token = request.GET.get('access_token')
+            if not access_token:
+                return JsonResponse({'message': 'ACCESS_TOKEN_DOES_NOT_EXIST'}, status=400)
+
+            headers  = {'Authorization': 'Bearer {}'.format(access_token)}
+            response = requests.get(KAKAO_USERINFO_REQUEST_URL, headers=headers).json()
+            
+            res_code = response.get('code')
+            if res_code == -401:
+                return JsonResponse({'message': 'code -401 : {}'.format(response.get('msg'))}, status=400)
+
+            kakao_user_id = response.get('id')
+
+            if kakao_user_id:
+                kakao_user_nickname = response['properties']['nickname']
+
+                user, _   = User.objects.get_or_create(kakao_id=kakao_user_id)
+                jwt_token = jwt.encode({'user_id': user.id}, SECRET_KEY, algorithm=HASHING_ALGORITHM)
+
+                user_info = {'token': jwt_token, 'nickname': kakao_user_nickname}
+                return JsonResponse(user_info, status=200)
+            else:
+                return JsonResponse({'message': 'INVALID_ACCESS_TOKEN'}, status=400)
+
+        except KeyError:
+            return JsonResponse({'message': 'KEY_ERROR'}, status=400)

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,60 @@
+import json
+import jwt
+from jwt.exceptions import InvalidSignatureError, DecodeError
+
+from django.http import JsonResponse
+
+from user.models import User
+
+from mukbang.settings import SECRET_KEY, HASHING_ALGORITHM
+
+
+# auth check with blocking access
+def auth_check(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            token = request.headers.get('Authorization')
+            if not token:
+                return JsonResponse({'message': 'TOKEN_DOES_NOT_EXIST'}, status=400)
+            
+            decoded_auth_token = jwt.decode(token, SECRET_KEY, algorithms=HASHING_ALGORITHM)
+
+            user_id = decoded_auth_token['user_id']
+            user    = User.objects.get(id=user_id)
+
+            request.user = user
+            return func(self, request, *args, **kwargs)
+
+        except InvalidSignatureError:
+            return JsonResponse({'message': 'SIGNATURE_VERIFICATION_FAILED'}, status=400)
+        except DecodeError:
+            return JsonResponse({'message': 'DECODE_ERROR'}, status=400)
+        except User.DoesNotExist:
+            return JsonResponse({'message': 'USER_DOES_NOT_EXIST'}, status=404)
+    return wrapper
+
+
+# user check without blocking access
+def user_check(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            token = request.headers.get('Authorization')
+            if not token:
+                request.user = None
+                return func(self, request, *args, **kwargs)
+
+            decoded_auth_token = jwt.decode(token, SECRET_KEY, algorithms=HASHING_ALGORITHM)
+            
+            user_id = decoded_auth_token['user_id']
+            user    = User.objects.get(id=user_id)
+
+            request.user = user
+            return func(self, request, *args, **kwargs)
+
+        except InvalidSignatureError:
+            return JsonResponse({'message': 'SIGNATURE_VERIFICATION_FAILED'}, status=400)
+        except DecodeError:
+            return JsonResponse({'message': 'DECODE_ERROR'}, status=400)
+        except User.DoesNotExist:
+            return JsonResponse({'message': 'USER_DOES_NOT_EXIST'}, stauts=404)
+    return wrapper


### PR DESCRIPTION
## 수정 사항 간략한 한줄 요약
- 카카오 소셜 로그인 구현
- decorators 추가
		 
## 수정 사항들 자세한 내용
- access_token 을 프론트 단에서 받으면, 해당 토큰으로 유저 정보 요청 및 db 에서 회원정보 저장 or 가져오기
- user_check decorator : 유저만 체크하는 데코레이터, block 하지 않음
- auth_check decorator : 접근 권한이 없는 api 요청시 block

## 기타 질문 및 특이 사항
- refresh_token 으로 토큰 갱신하는 부분은 프론트 파트인가요 ?
- unit test 시, 카카오 api 서버를 거쳐서 유저 정보를 받아와야하는데, 이건 response 자체를 mock 해야하나요?

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
